### PR TITLE
Fix broken urls

### DIFF
--- a/GPSOAuthSharp/GPSOAuthSharp.cs
+++ b/GPSOAuthSharp/GPSOAuthSharp.cs
@@ -136,7 +136,7 @@ namespace DankMemes.GPSOAuthSharp
             Dictionary<string, string> responseData = new Dictionary<string, string>();
             foreach (string line in text.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
             {
-                string[] parts = line.Split('=');
+                string[] parts = line.Split(new char[] { '=' }, 2);
                 responseData.Add(parts[0], parts[1]);
             }
             return responseData;


### PR DESCRIPTION
Fix broken urls when Response contains google url for 2 step verification.
ie : 
line = "Url=https://accounts.google.com/signin/continue?sarp=1&scc=1&continue=https%3A%2F%2Fa..."

in old code:
part[0] = "Url";
part[1] = "https://accounts.google.com/signin/continue?sarp"; 

now
part[0] = "Url";
part[1] = "https://accounts.google.com/signin/continue?sarp=1&scc=1&continue=https%3A%2F%2Fa...";  
